### PR TITLE
merge from frontend-svelte,template-arlac77-github,template-svelte-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,8 @@
 [![downloads](http://img.shields.io/npm/dm/@konsumation/frontend-svelte.svg?style=flat-square)](https://npmjs.org/package/@konsumation/frontend-svelte)
 [![GitHub Issues](https://img.shields.io/github/issues/konsumation/frontend-svelte.svg?style=flat-square)](https://github.com/konsumation/frontend-svelte/issues)
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fkonsumation%2Ffrontend-svelte%2Fbadge\&style=flat)](https://actions-badge.atrox.dev/konsumation/frontend-svelte/goto)
+[![Styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Known Vulnerabilities](https://snyk.io/test/github/konsumation/frontend-svelte/badge.svg)](https://snyk.io/test/github/konsumation/frontend-svelte)
 [![Coverage Status](https://coveralls.io/repos/konsumation/frontend-svelte/badge.svg)](https://coveralls.io/github/konsumation/frontend-svelte)
 [![Tested with TestCafe](https://img.shields.io/badge/tested%20with-TestCafe-2fa4cf.svg)](https://github.com/DevExpress/testcafe)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "startkonsum": "node_modules/@konsumation/konsum/src/konsum-cli.mjs -c tests/config start",
     "start": "vite",
     "test": "npm run test:ava && npm run test:cafe",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --app-init-delay 7000 --app vite",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --page-request-timeout 5000 --app-init-delay 8000 --app vite",
     "test:ava": "ava --timeout 4m tests/*-ava.mjs tests/*-ava-node.mjs",
     "cover": "c8 -x 'tests/**/*' --temp-directory build/tmp ava --timeout 4m tests/*-ava.mjs tests/*-ava-node.mjs && c8 report -r lcov -o build/coverage --temp-directory build/tmp",
     "docs": "documentation readme --section=API ./src/**/*.mjs",
@@ -61,7 +61,7 @@
     "@semantic-release/exec": "^6.0.3",
     "@semantic-release/github": "^10.0.5",
     "@semantic-release/release-notes-generator": "^13.0.0",
-    "@sveltejs/vite-plugin-svelte": "^3.1.0",
+    "@sveltejs/vite-plugin-svelte": "^3.1.1",
     "ava": "^6.1.3",
     "c8": "^9.1.0",
     "documentation": "^14.0.3",
@@ -93,6 +93,7 @@
     "dependencies": {
       "konsum": ">=6.1.16"
     },
+    "example": true,
     "frontend": true,
     "http.api.path": "${http.path}/api",
     "http.path": "${http.base.path}/konsum",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,8 @@
+import pacote from "pacote";
+
+export async function npmDepAnalyser(name, version, categorizer) {
+  const pkg = await pacote.manifest(`${name}@${version}`);
+  console.log(pkg);
+}
+
+npmDepAnalyser("pacote","^1");


### PR DESCRIPTION
package.json
---
- chore(scripts): add testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --page-request-timeout 5000 --app-init-delay 8000 --app vite (scripts.test:cafe)
chore(deps): add ^3.1.1 remove ^3.1.0 (devDependencies.@sveltejs/vite-plugin-svelte)
chore(package): add true (pkgbuild.example)

README.md
---
- docs(README): update from template

src/index.mjs
---
- add missing src/index.mjs from template

