### PR TITLE
merge from frontend-svelte,template-arlac77-github,template-svelte-app

### DIFF
--- a/.github/workflows/browser_ci.yml
+++ b/.github/workflows/browser_ci.yml
@@ -21,6 +21,7 @@ jobs:
           - chrome
           - firefox
         node-version:
+          - 20.15.0
           - 22.4.1
         firefox:
           - latest

--- a/README.md
+++ b/README.md
@@ -5,5 +5,8 @@
 [![downloads](http://img.shields.io/npm/dm/@konsumation/frontend-svelte.svg?style=flat-square)](https://npmjs.org/package/@konsumation/frontend-svelte)
 [![GitHub Issues](https://img.shields.io/github/issues/konsumation/frontend-svelte.svg?style=flat-square)](https://github.com/konsumation/frontend-svelte/issues)
 [![Build Status](https://img.shields.io/endpoint.svg?url=https%3A%2F%2Factions-badge.atrox.dev%2Fkonsumation%2Ffrontend-svelte%2Fbadge\&style=flat)](https://actions-badge.atrox.dev/konsumation/frontend-svelte/goto)
+[![Styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
+[![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+[![Known Vulnerabilities](https://snyk.io/test/github/konsumation/frontend-svelte/badge.svg)](https://snyk.io/test/github/konsumation/frontend-svelte)
 [![Coverage Status](https://coveralls.io/repos/konsumation/frontend-svelte/badge.svg)](https://coveralls.io/github/konsumation/frontend-svelte)
 [![Tested with TestCafe](https://img.shields.io/badge/tested%20with-TestCafe-2fa4cf.svg)](https://github.com/DevExpress/testcafe)

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "startkonsum": "node_modules/@konsumation/konsum/src/konsum-cli.mjs -c tests/config start",
     "start": "vite",
     "test": "npm run test:ava && npm run test:cafe",
-    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --app-init-delay 7000 --app vite",
+    "test:cafe": "testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --page-request-timeout 5000 --app-init-delay 8000 --app vite",
     "test:ava": "ava --timeout 4m tests/*-ava.mjs tests/*-ava-node.mjs",
     "cover": "c8 -x 'tests/**/*' --temp-directory build/tmp ava --timeout 4m tests/*-ava.mjs tests/*-ava-node.mjs && c8 report -r lcov -o build/coverage --temp-directory build/tmp",
     "docs": "documentation readme --section=API ./src/**/*.mjs",
@@ -63,15 +63,15 @@
     "@semantic-release/release-notes-generator": "^14.0.1",
     "@sveltejs/vite-plugin-svelte": "^3.1.1",
     "ava": "^6.1.3",
-    "c8": "^10.0.0",
+    "c8": "^10.1.2",
     "documentation": "^14.0.3",
-    "npm-pkgbuild": "^15.3.25",
+    "npm-pkgbuild": "^15.3.26",
     "semantic-release": "^24.0.0",
     "stylelint": "^16.7.0",
     "stylelint-config-standard": "^36.0.1",
     "svelte": "^5.0.0-next.184",
     "testcafe": "^3.6.2",
-    "vite": "^5.3.3",
+    "vite": "^5.3.4",
     "vite-plugin-compression2": "^1.1.2"
   },
   "optionalDependencies": {
@@ -93,6 +93,7 @@
     "dependencies": {
       "konsum": ">=6.11.16"
     },
+    "example": true,
     "frontend": true,
     "http.api.path": "${http.path}/api",
     "http.path": "${http.base.path}/konsum",

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -1,0 +1,8 @@
+import pacote from "pacote";
+
+export async function npmDepAnalyser(name, version, categorizer) {
+  const pkg = await pacote.manifest(`${name}@${version}`);
+  console.log(pkg);
+}
+
+npmDepAnalyser("pacote","^1");


### PR DESCRIPTION
package.json
---
- chore(scripts): add testcafe $BROWSER:headless tests/cafe/*-cafe.mjs --esm -s build/test --page-request-timeout 5000 --app-init-delay 8000 --app vite (scripts.test:cafe)
chore(deps): add ^10.1.2 remove ^10.0.0 (devDependencies.c8)
chore(deps): add ^15.3.26 remove ^15.3.25 (devDependencies.npm-pkgbuild)
chore(deps): add ^5.3.4 remove ^5.3.3 (devDependencies.vite)
chore(package): add true (pkgbuild.example)

.github/workflows/browser_ci.yml
---
- chore(deps): add 20.15.0 (jobs.test.strategy.matrix.node-version)

README.md
---
- docs(README): update from template

src/index.mjs
---
- add missing src/index.mjs from template

